### PR TITLE
Checklist: DM can push required tasks to managers per store + period

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -249,6 +249,46 @@
     </div>
 </div>
 
+<div class="modal-menu manage-menu" id="managerChecklistDropdown">
+    <div class="modal-header">
+        <h3>Manager Checklist</h3>
+        <button class="modal-close-btn" onclick="closeAllModals()">✖</button>
+    </div>
+    <div class="manage-content">
+        <div class="mcl-add-form">
+            <div class="mcl-add-row">
+                <div class="mcl-field mcl-field-period">
+                    <label class="form-label-caps">Time Period</label>
+                    <select id="mcl-period" class="form-input-lg">
+                        <option value="daily">Daily</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                        <option value="quarterly">Quarterly</option>
+                    </select>
+                </div>
+                <div class="mcl-field mcl-field-text">
+                    <label class="form-label-caps">Required Task</label>
+                    <input type="text" id="mcl-text" class="form-input-lg" placeholder="e.g. Confirm register float counted" onkeydown="if(event.key==='Enter')addRequiredTask()">
+                </div>
+            </div>
+            <div class="mcl-field">
+                <label class="form-label-caps">Applies To <button type="button" class="mcl-allbtn" onclick="mclToggleAllStores()">Toggle all</button></label>
+                <div class="mcl-store-checks" id="mcl-stores">
+                    <label><input type="checkbox" value="OVL"><span>OVL</span></label>
+                    <label><input type="checkbox" value="LEE"><span>LEE</span></label>
+                    <label><input type="checkbox" value="WSP"><span>WSP</span></label>
+                    <label><input type="checkbox" value="MPL"><span>MPL</span></label>
+                    <label><input type="checkbox" value="BAL"><span>BAL</span></label>
+                    <label><input type="checkbox" value="CORP"><span>Corp</span></label>
+                </div>
+            </div>
+            <button class="btn-primary mcl-add-btn" id="mcl-add-btn" onclick="addRequiredTask()">+ Add Required Task</button>
+        </div>
+        <div class="mcl-existing-label">Current required tasks</div>
+        <div id="mcl-list"><div class="status-message">Loading…</div></div>
+    </div>
+</div>
+
 <div class="modal-menu manage-menu" id="manageHotkeysDropdown">
     <div class="modal-header">
         <h3>Edit Hotkeys</h3>
@@ -464,6 +504,7 @@
     <div class="tools-group dynamic-module-block role-district-manager">
       <div class="tools-group-label">🏪 Store Ops</div>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); openScorecardModal();"><span class="tools-item-icon">🏆</span>Submit Scorecard</a>
+      <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleManagerChecklist();"><span class="tools-item-icon">📋</span>Manager Checklist</a>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleSendCommentModal();"><span class="tools-item-icon">💬</span>Send Store Comment</a>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -285,6 +285,46 @@
     </div>
 </div>
 
+<div class="modal-menu manage-menu" id="managerChecklistDropdown">
+    <div class="modal-header">
+        <h3>Manager Checklist</h3>
+        <button class="modal-close-btn" onclick="closeAllModals()">✖</button>
+    </div>
+    <div class="manage-content">
+        <div class="mcl-add-form">
+            <div class="mcl-add-row">
+                <div class="mcl-field mcl-field-period">
+                    <label class="form-label-caps">Time Period</label>
+                    <select id="mcl-period" class="form-input-lg">
+                        <option value="daily">Daily</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                        <option value="quarterly">Quarterly</option>
+                    </select>
+                </div>
+                <div class="mcl-field mcl-field-text">
+                    <label class="form-label-caps">Required Task</label>
+                    <input type="text" id="mcl-text" class="form-input-lg" placeholder="e.g. Confirm register float counted" onkeydown="if(event.key==='Enter')addRequiredTask()">
+                </div>
+            </div>
+            <div class="mcl-field">
+                <label class="form-label-caps">Applies To <button type="button" class="mcl-allbtn" onclick="mclToggleAllStores()">Toggle all</button></label>
+                <div class="mcl-store-checks" id="mcl-stores">
+                    <label><input type="checkbox" value="OVL"><span>OVL</span></label>
+                    <label><input type="checkbox" value="LEE"><span>LEE</span></label>
+                    <label><input type="checkbox" value="WSP"><span>WSP</span></label>
+                    <label><input type="checkbox" value="MPL"><span>MPL</span></label>
+                    <label><input type="checkbox" value="BAL"><span>BAL</span></label>
+                    <label><input type="checkbox" value="CORP"><span>Corp</span></label>
+                </div>
+            </div>
+            <button class="btn-primary mcl-add-btn" id="mcl-add-btn" onclick="addRequiredTask()">+ Add Required Task</button>
+        </div>
+        <div class="mcl-existing-label">Current required tasks</div>
+        <div id="mcl-list"><div class="status-message">Loading…</div></div>
+    </div>
+</div>
+
 <div class="modal-menu manage-menu" id="manageHotkeysDropdown">
     <div class="modal-header">
         <h3>Edit Hotkeys</h3>
@@ -1143,6 +1183,7 @@
     <div class="tools-group dynamic-module-block role-district-manager">
       <div class="tools-group-label">🏪 Store Ops</div>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); openScorecardModal();"><span class="tools-item-icon">🏆</span>Submit Scorecard</a>
+      <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleManagerChecklist();"><span class="tools-item-icon">📋</span>Manager Checklist</a>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleVarianceInput();"><span class="tools-item-icon">📊</span>Submit Variance Report</a>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleSendCommentModal();"><span class="tools-item-icon">💬</span>Send Store Comment</a>
     </div>

--- a/speeks.js
+++ b/speeks.js
@@ -8596,6 +8596,146 @@ async function saveManageHotkeys() {
     }
 }
 
+// ===== DM: MANAGER CHECKLIST (required tasks pushed to managers) =====
+// Lets the District Manager create/edit/remove the "required" (non-deletable)
+// checklist items managers see, targeted at specific stores per time period.
+const MCL_PERIOD_LABELS = { daily: 'Daily', weekly: 'Weekly', monthly: 'Monthly', quarterly: 'Quarterly' };
+
+function _mclRole() {
+    return (sessionStorage.getItem('speeksUserRole') || '').toLowerCase();
+}
+
+async function toggleManagerChecklist() {
+    const dropdown = document.getElementById('managerChecklistDropdown');
+    if (!dropdown) return;
+
+    const isOpen = dropdown.classList.contains('show');
+    closeAllModals();
+    if (isOpen) return;
+
+    dropdown.classList.add('show');
+    lockAndBlurScreen();
+
+    // Reset the add form to a clean state each time it opens
+    const text = document.getElementById('mcl-text'); if (text) text.value = '';
+    const period = document.getElementById('mcl-period'); if (period) period.value = 'daily';
+    document.querySelectorAll('#mcl-stores input[type="checkbox"]').forEach(c => c.checked = false);
+
+    await loadRequiredTasks();
+}
+
+function mclToggleAllStores() {
+    const boxes = [...document.querySelectorAll('#mcl-stores input[type="checkbox"]')];
+    const allOn = boxes.length > 0 && boxes.every(b => b.checked);
+    boxes.forEach(b => b.checked = !allOn);
+}
+
+async function loadRequiredTasks() {
+    const list = document.getElementById('mcl-list');
+    if (!list) return;
+    list.innerHTML = '<div class="status-message">Loading required tasks…</div>';
+    try {
+        const res = await fetch(`${CHECKLIST_URL}?action=listRequired&v=${Date.now()}`);
+        const data = await res.json();
+        renderRequiredTasks(data.tasks || []);
+    } catch (e) {
+        list.innerHTML = '<div class="status-message" style="color: var(--red-alert);">Failed to load required tasks.</div>';
+    }
+}
+
+function renderRequiredTasks(tasks) {
+    const list = document.getElementById('mcl-list');
+    if (!list) return;
+
+    if (!tasks.length) {
+        list.innerHTML = '<div style="text-align:center; padding:18px; color:#94a3b8; font-size:12px; font-weight:600;">No required tasks yet. Add one above.</div>';
+        return;
+    }
+
+    const order = ['daily', 'weekly', 'monthly', 'quarterly'];
+    const byPeriod = {};
+    tasks.forEach(t => { (byPeriod[t.tab] = byPeriod[t.tab] || []).push(t); });
+
+    let html = '';
+    order.forEach(period => {
+        const items = byPeriod[period];
+        if (!items || !items.length) return;
+        html += `<div class="mcl-group-label">${MCL_PERIOD_LABELS[period] || period}</div>`;
+        items.forEach(t => {
+            const badges = (t.stores || []).length
+                ? t.stores.map(s => `<span class="mcl-badge">${s === 'CORP' ? 'Corp' : s}</span>`).join('')
+                : '<span class="mcl-badge mcl-badge-none">No stores</span>';
+            html += `
+            <div class="mcl-row" data-id="${t.id}">
+                <div class="mcl-row-main">
+                    <span class="mcl-row-text">${escapeHtml(t.text)}</span>
+                    <div class="mcl-row-badges">${badges}</div>
+                </div>
+                <div class="mcl-row-actions">
+                    <button class="mcl-edit-btn" title="Edit task text" onclick="editRequiredTask('${t.id}')">✎</button>
+                    <button class="mcl-del-btn" title="Delete for all managers" onclick="deleteRequiredTask('${t.id}')">✖</button>
+                </div>
+            </div>`;
+        });
+    });
+    list.innerHTML = html;
+}
+
+async function addRequiredTask() {
+    const btn = document.getElementById('mcl-add-btn');
+    const text = (document.getElementById('mcl-text').value || '').trim();
+    const tab = document.getElementById('mcl-period').value;
+    const stores = [...document.querySelectorAll('#mcl-stores input[type="checkbox"]:checked')].map(c => c.value);
+
+    if (!text) { alert('Enter the task text.'); return; }
+    if (!stores.length) { alert('Pick at least one store this task applies to.'); return; }
+
+    btn.disabled = true;
+    btn.textContent = 'Saving…';
+    try {
+        await postWrite(CHECKLIST_URL, {
+            action: 'addRequired',
+            tab, text, stores,
+            user: sessionStorage.getItem('speeksUserName') || '',
+            role: _mclRole()
+        });
+        document.getElementById('mcl-text').value = '';
+        document.querySelectorAll('#mcl-stores input[type="checkbox"]').forEach(c => c.checked = false);
+        await loadRequiredTasks();
+    } catch (e) {
+        alert('Could not add task: ' + (e.message || e));
+    } finally {
+        btn.disabled = false;
+        btn.textContent = '+ Add Required Task';
+    }
+}
+
+async function deleteRequiredTask(id) {
+    if (!confirm('Delete this required task for all managers it applies to? This cannot be undone.')) return;
+    try {
+        await postWrite(CHECKLIST_URL, { action: 'deleteRequired', id, role: _mclRole() });
+        await loadRequiredTasks();
+    } catch (e) {
+        alert('Could not delete task: ' + (e.message || e));
+    }
+}
+
+async function editRequiredTask(id) {
+    const row = document.querySelector(`.mcl-row[data-id="${id}"]`);
+    if (!row) return;
+    const current = row.querySelector('.mcl-row-text').textContent;
+    const next = prompt('Edit task text:', current);
+    if (next === null) return; // cancelled
+    const trimmed = next.trim();
+    if (!trimmed || trimmed === current) return;
+    try {
+        await postWrite(CHECKLIST_URL, { action: 'editRequired', id, text: trimmed, role: _mclRole() });
+        await loadRequiredTasks();
+    } catch (e) {
+        alert('Could not edit task: ' + (e.message || e));
+    }
+}
+
 // --- DM SCORECARD SUBMISSION LOGIC ---
 const SCORECARD_CATEGORIES = [
     "Front of House Cleanliness",

--- a/stats.html
+++ b/stats.html
@@ -261,6 +261,46 @@
     </div>
 </div>
 
+<div class="modal-menu manage-menu" id="managerChecklistDropdown">
+    <div class="modal-header">
+        <h3>Manager Checklist</h3>
+        <button class="modal-close-btn" onclick="closeAllModals()">✖</button>
+    </div>
+    <div class="manage-content">
+        <div class="mcl-add-form">
+            <div class="mcl-add-row">
+                <div class="mcl-field mcl-field-period">
+                    <label class="form-label-caps">Time Period</label>
+                    <select id="mcl-period" class="form-input-lg">
+                        <option value="daily">Daily</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                        <option value="quarterly">Quarterly</option>
+                    </select>
+                </div>
+                <div class="mcl-field mcl-field-text">
+                    <label class="form-label-caps">Required Task</label>
+                    <input type="text" id="mcl-text" class="form-input-lg" placeholder="e.g. Confirm register float counted" onkeydown="if(event.key==='Enter')addRequiredTask()">
+                </div>
+            </div>
+            <div class="mcl-field">
+                <label class="form-label-caps">Applies To <button type="button" class="mcl-allbtn" onclick="mclToggleAllStores()">Toggle all</button></label>
+                <div class="mcl-store-checks" id="mcl-stores">
+                    <label><input type="checkbox" value="OVL"><span>OVL</span></label>
+                    <label><input type="checkbox" value="LEE"><span>LEE</span></label>
+                    <label><input type="checkbox" value="WSP"><span>WSP</span></label>
+                    <label><input type="checkbox" value="MPL"><span>MPL</span></label>
+                    <label><input type="checkbox" value="BAL"><span>BAL</span></label>
+                    <label><input type="checkbox" value="CORP"><span>Corp</span></label>
+                </div>
+            </div>
+            <button class="btn-primary mcl-add-btn" id="mcl-add-btn" onclick="addRequiredTask()">+ Add Required Task</button>
+        </div>
+        <div class="mcl-existing-label">Current required tasks</div>
+        <div id="mcl-list"><div class="status-message">Loading…</div></div>
+    </div>
+</div>
+
 <div class="modal-menu manage-menu" id="manageHotkeysDropdown">
     <div class="modal-header">
         <h3>Edit Hotkeys</h3>
@@ -641,6 +681,7 @@
     <div class="tools-group dynamic-module-block role-district-manager">
       <div class="tools-group-label">🏪 Store Ops</div>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); openScorecardModal();"><span class="tools-item-icon">🏆</span>Submit Scorecard</a>
+      <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleManagerChecklist();"><span class="tools-item-icon">📋</span>Manager Checklist</a>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleSendCommentModal();"><span class="tools-item-icon">💬</span>Send Store Comment</a>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -6417,3 +6417,32 @@ input.kpi-grid-input.kpi-cell-red:disabled   { background: #fee2e2 !important; c
 @media (prefers-reduced-motion: reduce) {
     .kpi-due-dot::before, .kpi-due-pill, .kpi-update-trigger-btn.kpi-due-pulse { animation: none; }
 }
+
+/* ===== DM Manager Checklist (required tasks) modal ===== */
+.mcl-add-form { display: flex; flex-direction: column; gap: 12px; }
+.mcl-add-row { display: flex; gap: 10px; }
+.mcl-field { display: flex; flex-direction: column; gap: 5px; }
+.mcl-field-period { flex: 0 0 130px; }
+.mcl-field-text { flex: 1 1 auto; min-width: 0; }
+.mcl-field .form-label-caps { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.mcl-allbtn { background: #eef2ff; color: #4338ca; border: none; border-radius: 6px; padding: 3px 8px; font-size: 10px; font-weight: 700; cursor: pointer; }
+.mcl-allbtn:hover { background: #e0e7ff; }
+.mcl-store-checks { display: flex; flex-wrap: wrap; gap: 8px; }
+.mcl-store-checks label { display: flex; align-items: center; gap: 6px; background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 8px; padding: 6px 11px; font-size: 12px; font-weight: 700; color: #475569; cursor: pointer; user-select: none; }
+.mcl-store-checks label:has(input:checked) { background: #eef2ff; border-color: #a5b4fc; color: #4338ca; }
+.mcl-store-checks input { cursor: pointer; width: 14px; height: 14px; }
+.mcl-add-btn { align-self: flex-start; }
+.mcl-existing-label { margin: 16px 0 8px; font-size: 10px; font-weight: 800; letter-spacing: .5px; text-transform: uppercase; color: #94a3b8; border-top: 1px solid #e2e8f0; padding-top: 14px; }
+.mcl-group-label { font-size: 10px; font-weight: 800; letter-spacing: .5px; text-transform: uppercase; color: #6366f1; margin: 10px 0 4px; }
+.mcl-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 6px; }
+.mcl-row-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.mcl-row-text { font-size: 13px; font-weight: 600; color: #1e293b; }
+.mcl-row-badges { display: flex; flex-wrap: wrap; gap: 4px; }
+.mcl-badge { font-size: 9px; font-weight: 800; letter-spacing: .3px; background: #eef2ff; color: #4338ca; border-radius: 5px; padding: 2px 6px; }
+.mcl-badge-none { background: #fef2f2; color: #dc2626; }
+.mcl-row-actions { display: flex; gap: 6px; flex: 0 0 auto; }
+.mcl-edit-btn, .mcl-del-btn { width: 26px; height: 26px; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 700; line-height: 1; }
+.mcl-edit-btn { background: #f1f5f9; color: #475569; }
+.mcl-del-btn { background: #fef2f2; color: #dc2626; }
+.mcl-edit-btn:hover { background: #e2e8f0; }
+.mcl-del-btn:hover { background: #fee2e2; }

--- a/workspace.html
+++ b/workspace.html
@@ -257,6 +257,46 @@
     </div>
 </div>
 
+<div class="modal-menu manage-menu" id="managerChecklistDropdown">
+    <div class="modal-header">
+        <h3>Manager Checklist</h3>
+        <button class="modal-close-btn" onclick="closeAllModals()">✖</button>
+    </div>
+    <div class="manage-content">
+        <div class="mcl-add-form">
+            <div class="mcl-add-row">
+                <div class="mcl-field mcl-field-period">
+                    <label class="form-label-caps">Time Period</label>
+                    <select id="mcl-period" class="form-input-lg">
+                        <option value="daily">Daily</option>
+                        <option value="weekly">Weekly</option>
+                        <option value="monthly">Monthly</option>
+                        <option value="quarterly">Quarterly</option>
+                    </select>
+                </div>
+                <div class="mcl-field mcl-field-text">
+                    <label class="form-label-caps">Required Task</label>
+                    <input type="text" id="mcl-text" class="form-input-lg" placeholder="e.g. Confirm register float counted" onkeydown="if(event.key==='Enter')addRequiredTask()">
+                </div>
+            </div>
+            <div class="mcl-field">
+                <label class="form-label-caps">Applies To <button type="button" class="mcl-allbtn" onclick="mclToggleAllStores()">Toggle all</button></label>
+                <div class="mcl-store-checks" id="mcl-stores">
+                    <label><input type="checkbox" value="OVL"><span>OVL</span></label>
+                    <label><input type="checkbox" value="LEE"><span>LEE</span></label>
+                    <label><input type="checkbox" value="WSP"><span>WSP</span></label>
+                    <label><input type="checkbox" value="MPL"><span>MPL</span></label>
+                    <label><input type="checkbox" value="BAL"><span>BAL</span></label>
+                    <label><input type="checkbox" value="CORP"><span>Corp</span></label>
+                </div>
+            </div>
+            <button class="btn-primary mcl-add-btn" id="mcl-add-btn" onclick="addRequiredTask()">+ Add Required Task</button>
+        </div>
+        <div class="mcl-existing-label">Current required tasks</div>
+        <div id="mcl-list"><div class="status-message">Loading…</div></div>
+    </div>
+</div>
+
 <div class="modal-menu manage-menu" id="manageHotkeysDropdown">
     <div class="modal-header">
         <h3>Edit Hotkeys</h3>
@@ -517,6 +557,7 @@
     <div class="tools-group dynamic-module-block role-district-manager">
       <div class="tools-group-label">🏪 Store Ops</div>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); openScorecardModal();"><span class="tools-item-icon">🏆</span>Submit Scorecard</a>
+      <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleManagerChecklist();"><span class="tools-item-icon">📋</span>Manager Checklist</a>
       <a class="tools-item dynamic-module-flex role-district-manager" onclick="_closeToolsPanel(); toggleSendCommentModal();"><span class="tools-item-icon">💬</span>Send Store Comment</a>
     </div>
 


### PR DESCRIPTION
Adds a DM-only "Manager Checklist" tool (Tools panel) to create, edit, and delete the required (non-deletable) checklist items managers see, targeted at specific stores per time period.

- Activates the previously-unused applies_* columns for per-store targeting
- New checklist edge-fn actions: addRequired / editRequired / deleteRequired / listRequired, all gated to district manager + ceo
- Manager read now includes tasks flagged for their store; is_global marks them required. Fully backward compatible with existing RETAIL/CORP tasks
- Modal + styles added to all four pages (index/workspace/docs/stats)

Edge function deployed separately (checklist v6).